### PR TITLE
Compare images with a perceptual hash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,10 +33,11 @@ public static class ModuleInitializer
     public static void Initialize()
     {
         VerifyDocNet.Initialize();
+        VerifyImageMagick.RegisterComparers(threshold: 0.05, ImageMagick.ErrorMetric.PerceptualHash);
     }
 }
 ```
-<sup><a href='/src/Tests/ModuleInitializer.cs#L1-L11' title='Snippet source file'>snippet source</a> | <a href='#snippet-ModuleInitializer.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/ModuleInitializer.cs#L1-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-ModuleInitializer.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Tests/ModuleInitializer.cs
+++ b/src/Tests/ModuleInitializer.cs
@@ -7,5 +7,6 @@ public static class ModuleInitializer
     public static void Initialize()
     {
         VerifyDocNet.Initialize();
+        VerifyImageMagick.RegisterComparers(threshold: 0.05, ImageMagick.ErrorMetric.PerceptualHash);
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Verify.ImageMagick" Version="2.10.0" />
     <PackageReference Include="Verify.NUnit" Version="11.27.0" />
     <ProjectReference Include="..\Verify.DocNet\Verify.DocNet.csproj" />
     <PackageReference Include="ProjectDefaults" Version="1.0.58" PrivateAssets="All" />


### PR DESCRIPTION
Rendering PDF to PNG is not pixel perfect across different operating systems. Comparing the resulting images with a perceptual has accounts for those small rendering differences.

This makes the test pass on macOS.