### PR TITLE
Use ImageSharp instead of System.Drawing.Common

### DIFF
--- a/src/Verify.DocNet/Verify.DocNet.csproj
+++ b/src/Verify.DocNet/Verify.DocNet.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Docnet.Core" Version="2.3.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="Verify" Version="11.27.0" />
     <PackageReference Include="ProjectDefaults" Version="1.0.58" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />

--- a/src/Verify.DocNet/VerifyDocNet_Pdf.cs
+++ b/src/Verify.DocNet/VerifyDocNet_Pdf.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Docnet.Core;
 using Docnet.Core.Converters;
 using Docnet.Core.Readers;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace VerifyTests
 {
@@ -41,25 +40,12 @@ namespace VerifyTests
                 var width = reader.GetPageWidth();
                 var height = reader.GetPageHeight();
 
-                using var bitmap = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-
-                AddBytes(bitmap, rawBytes);
+                var image = Image.LoadPixelData<Bgra32>(rawBytes, width, height);
 
                 var stream = new MemoryStream();
-                bitmap.Save(stream, ImageFormat.Png);
+                image.SaveAsPng(stream);
                 yield return new("png", stream);
             }
-        }
-
-        static void AddBytes(Bitmap bmp, byte[] rawBytes)
-        {
-            var rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
-
-            var bmpData = bmp.LockBits(rect, ImageLockMode.WriteOnly, bmp.PixelFormat);
-            var pNative = bmpData.Scan0;
-
-            Marshal.Copy(rawBytes, 0, pNative, rawBytes.Length);
-            bmp.UnlockBits(bmpData);
         }
     }
 }


### PR DESCRIPTION
System.Drawing.Common is [becoming Windows-only](https://github.com/dotnet/designs/blob/main/accepted/2021/system-drawing-win-only/system-drawing-win-only.md) in .NET 6 so let's use ImageSharp instead which is a truly cross-platform solution.