### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/src/Verify.DocNet/Verify.DocNet.csproj
+++ b/src/Verify.DocNet/Verify.DocNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Docnet.Core" Version="2.3.1" />


### PR DESCRIPTION
All the dependencies (Docnet.Core, SixLabors.ImageSharp and Verify) support .NET Standard 2.0 and Verify.DocNet code itself is also .NET Standard 2.0 compliant.

This makes Verify.DocNet available to .NET Framework 4.7.2 and .NET Core 2.0+ for free and reduces the size of the NuGet package since only one dll is required instead of two.