### PR TITLE
Normalize Dublin Core <dc:date> in PdfNormalizer

### DIFF
--- a/src/Tests/PdfNormalizerTests.cs
+++ b/src/Tests/PdfNormalizerTests.cs
@@ -29,6 +29,16 @@ public class PdfNormalizerTests
     }
 
     [Test]
+    public void NeutralizesDublinCoreDate()
+    {
+        // Some producers (for example Apache FOP) write the render time into the Dublin Core
+        // <dc:date> element, a volatile per-render value like its xmp:* date siblings.
+        var input = "<dc:date>2024-01-15T09:30:00+05:30</dc:date>";
+        var expected = "<dc:date>0000-00-00T00:00:00+00:00</dc:date>";
+        Assert.That(Normalize(input), Is.EqualTo(expected));
+    }
+
+    [Test]
     public void CollapsesDifferingValuesToTheSameOutput()
     {
         // The same producer emits a stable structure across runs, so two documents differing only

--- a/src/Verify.DocNet/PdfNormalizer.cs
+++ b/src/Verify.DocNet/PdfNormalizer.cs
@@ -42,6 +42,7 @@ static class PdfNormalizer
         ZeroXmpElement(data, "<xmp:CreateDate"u8, Fill.Digits);
         ZeroXmpElement(data, "<xmp:ModifyDate"u8, Fill.Digits);
         ZeroXmpElement(data, "<xmp:MetadataDate"u8, Fill.Digits);
+        ZeroXmpElement(data, "<dc:date"u8, Fill.Digits);
 
         // XMP per-generation identifiers.
         ZeroXmpElement(data, "<xmpMM:DocumentID"u8, Fill.All);


### PR DESCRIPTION
PdfNormalizer zeroed the xmp:CreateDate/ModifyDate/MetadataDate elements but not the Dublin Core <dc:date> element. 

Apache FOP writes the render timestamp into <dc:date>, so the #pdf snapshot target (added in #516) was non-deterministic for FOP-produced PDFs while the sibling dates were neutralized.

This PR adds <dc:date> to the normalized set together with a focused test.