### PR TITLE
Normalize Dublin Core dc:date, including the rdf:Seq array form

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;NU1608;NU1109</NoWarn>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <LangVersion>preview</LangVersion>
     <SignAssembly>false</SignAssembly>

--- a/src/Tests/PdfNormalizerTests.cs
+++ b/src/Tests/PdfNormalizerTests.cs
@@ -26,6 +26,66 @@ public class PdfNormalizerTests
     }
 
     [Test]
+    public void NeutralizesDublinCoreDate()
+    {
+        // Some producers (for example older Apache FOP) write the render time straight into the
+        // Dublin Core <dc:date> element as simple text content.
+        var input = "<dc:date>2024-01-15T09:30:00+05:30</dc:date>";
+        var expected = "<dc:date>0000-00-00T00:00:00+00:00</dc:date>";
+        Assert.That(Normalize(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void NeutralizesDublinCoreDateSeq()
+    {
+        // Per the XMP spec dc:date is an ordered array (seq Date), so a spec-compliant producer
+        // (current Apache FOP) nests the render time in rdf:Seq/rdf:li rather than as direct text.
+        var input = "<dc:date><rdf:Seq><rdf:li>2024-01-15T09:30:00+05:30</rdf:li></rdf:Seq></dc:date>";
+        var expected = "<dc:date><rdf:Seq><rdf:li>0000-00-00T00:00:00+00:00</rdf:li></rdf:Seq></dc:date>";
+        Assert.That(Normalize(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void NeutralizesDublinCoreDateSeqWithWhitespaceAndMultipleEntries()
+    {
+        // Pretty-printed with indentation and more than one date in the sequence: markup and
+        // whitespace are preserved while every date value is zeroed.
+        var input =
+            """
+            <dc:date>
+              <rdf:Seq>
+                <rdf:li>2024-01-15T09:30:00+05:30</rdf:li>
+                <rdf:li>2019-12-31T23:59:59Z</rdf:li>
+              </rdf:Seq>
+            </dc:date>
+            """;
+        var expected =
+            """
+            <dc:date>
+              <rdf:Seq>
+                <rdf:li>0000-00-00T00:00:00+00:00</rdf:li>
+                <rdf:li>0000-00-00T00:00:00Z</rdf:li>
+              </rdf:Seq>
+            </dc:date>
+            """;
+        Assert.That(Normalize(input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void LeavesNonDateRdfArraysUntouched()
+    {
+        // The rdf:li descent is scoped to dc:date, so digits in a sibling array (here dc:subject)
+        // must survive.
+        var input =
+            "<dc:subject><rdf:Bag><rdf:li>topic 2024</rdf:li></rdf:Bag></dc:subject>" +
+            "<dc:date><rdf:Seq><rdf:li>2024-01-15T09:30:00Z</rdf:li></rdf:Seq></dc:date>";
+        var expected =
+            "<dc:subject><rdf:Bag><rdf:li>topic 2024</rdf:li></rdf:Bag></dc:subject>" +
+            "<dc:date><rdf:Seq><rdf:li>0000-00-00T00:00:00Z</rdf:li></rdf:Seq></dc:date>";
+        Assert.That(Normalize(input), Is.EqualTo(expected));
+    }
+
+    [Test]
     public void CollapsesDifferingValuesToTheSameOutput()
     {
         // The same producer emits a stable structure across runs, so two documents differing only
@@ -53,6 +113,22 @@ public class PdfNormalizerTests
 
         using var reader = DocLib.Instance.GetDocReader(data, new(scalingFactor: 2));
         Assert.That(reader.GetPageCount(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void NeutralizesFopStyleXmp()
+    {
+        // sample-fop.pdf carries an uncompressed FOP-style XMP packet whose dc:date render time is
+        // nested in rdf:Seq/rdf:li. It must be neutralized while the document still loads.
+        var data = File.ReadAllBytes("sample-fop.pdf");
+        PdfNormalizer.Normalize(data);
+
+        var text = Encoding.Latin1.GetString(data);
+        Assert.That(text, Does.Contain("<rdf:li>0000-00-00T00:00:00+00:00</rdf:li>"));
+        Assert.That(text, Does.Not.Contain("2024-01-15"));
+
+        using var reader = DocLib.Instance.GetDocReader(data, new(scalingFactor: 2));
+        Assert.That(reader.GetPageCount(), Is.EqualTo(1));
     }
 
     [Test]

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -22,5 +22,8 @@
     <None Update="sample.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="sample-fop.pdf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/Tests/sample-fop.pdf
+++ b/src/Tests/sample-fop.pdf
@@ -1,0 +1,50 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>
+endobj
+4 0 obj
+<< /Producer (Apache FOP Version 2.9) /CreationDate (D:20240115093000+05'30') /ModDate (D:20240115093000Z) >>
+endobj
+5 0 obj
+<< /Type /Metadata /Subtype /XML /Length 686 >>
+stream
+<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
+   <dc:date>
+    <rdf:Seq>
+     <rdf:li>2024-01-15T09:30:00+05:30</rdf:li>
+    </rdf:Seq>
+   </dc:date>
+  </rdf:Description>
+  <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+   <xmp:CreateDate>2024-01-15T09:30:00+05:30</xmp:CreateDate>
+   <xmp:ModifyDate>2024-01-15T09:30:00+05:30</xmp:ModifyDate>
+   <xmp:MetadataDate>2024-01-15T09:30:00+05:30</xmp:MetadataDate>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000225 00000 n 
+0000000350 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R /Info 4 0 R /ID [<0123456789ABCDEF0123456789ABCDEF> <FEDCBA9876543210FEDCBA9876543210>] >>
+startxref
+1117
+%%EOF

--- a/src/Verify.DocNet/PdfNormalizer.cs
+++ b/src/Verify.DocNet/PdfNormalizer.cs
@@ -43,6 +43,11 @@ static class PdfNormalizer
         ZeroXmpElement(data, "<xmp:ModifyDate"u8, Fill.Digits);
         ZeroXmpElement(data, "<xmp:MetadataDate"u8, Fill.Digits);
 
+        // Dublin Core date. Unlike the xmp:* dates above it is an ordered array (seq Date), so the
+        // value is nested inside rdf:Seq/rdf:li rather than being direct text content of the element
+        // (this is what Apache FOP emits).
+        ZeroXmpElementTree(data, "<dc:date"u8, "</dc:date>"u8, Fill.Digits);
+
         // XMP per-generation identifiers.
         ZeroXmpElement(data, "<xmpMM:DocumentID"u8, Fill.All);
         ZeroXmpElement(data, "<xmpMM:InstanceID"u8, Fill.All);
@@ -144,10 +149,76 @@ static class PdfNormalizer
         var pos = 0;
         while (true)
         {
+            var start = NextXmpElementContent(data, openTag, ref pos);
+            if (start < 0)
+            {
+                return;
+            }
+
+            var end = FindByte(data, start, (byte) '<');
+            Overwrite(data, start, end, fill);
+            pos = end;
+        }
+    }
+
+    // Like ZeroXmpElement, but descends through child markup and zeroes the content of every text
+    // node up to the matching close tag. XMP array properties (for example dc:date, a "seq Date")
+    // wrap their value in an rdf:Seq/rdf:li list, so the volatile value is not direct text content of
+    // the named element and ZeroXmpElement alone would step over it.
+    static void ZeroXmpElementTree(byte[] data, ReadOnlySpan<byte> openTag, ReadOnlySpan<byte> closeTag, Fill fill)
+    {
+        var pos = 0;
+        while (true)
+        {
+            var start = NextXmpElementContent(data, openTag, ref pos);
+            if (start < 0)
+            {
+                return;
+            }
+
+            var closeHit = data.AsSpan(start).IndexOf(closeTag);
+            if (closeHit < 0)
+            {
+                return;
+            }
+
+            var end = start + closeHit;
+            var i = start;
+            while (i < end)
+            {
+                // Skip markup so only text nodes are altered, never element or attribute names.
+                if (data[i] == (byte) '<')
+                {
+                    i = FindByte(data, i, (byte) '>');
+                    if (i < end)
+                    {
+                        i++;
+                    }
+
+                    continue;
+                }
+
+                var textEnd = FindByte(data, i, (byte) '<');
+                Overwrite(data, i, textEnd, fill);
+                i = textEnd;
+            }
+
+            pos = end;
+        }
+    }
+
+    // Locates the next element whose opening tag is 'openTag', returning the index of its content
+    // (the byte after '>'), or -1 when no further match exists. A longer look-alike name or a
+    // self-closing tag is skipped internally. 'pos' is advanced past the opening tag so scanning can
+    // resume from the returned index.
+    static int NextXmpElementContent(byte[] data, ReadOnlySpan<byte> openTag, ref int pos)
+    {
+        while (true)
+        {
             var hit = data.AsSpan(pos).IndexOf(openTag);
             if (hit < 0)
             {
-                return;
+                return -1;
             }
 
             var i = pos + hit + openTag.Length;
@@ -174,19 +245,17 @@ static class PdfNormalizer
 
             if (i >= data.Length)
             {
-                return;
+                return -1;
             }
 
             i++;
+            pos = i;
             if (lastSignificant == (byte) '/')
             {
                 continue;
             }
 
-            var start = i;
-            var end = FindByte(data, start, (byte) '<');
-            Overwrite(data, start, end, fill);
-            pos = end;
+            return i;
         }
     }
 


### PR DESCRIPTION
dc:date is an XMP ordered array (seq Date), so spec-compliant producers (current Apache FOP) nest the render timestamp in rdf:Seq/rdf:li rather than as direct text content. Zeroing only the element's own text — as the xmp:* dates are handled — left the value untouched, so the #pdf snapshot target from #516 stayed non-deterministic for FOP output.

Add ZeroXmpElementTree, which descends through child markup and zeroes the digits of every text node up to the matching close tag, scoped to dc:date so sibling arrays (dc:subject, ...) are left intact. The shared open-tag scan is factored into NextXmpElementContent; the simple-element path is behaviour-identical.

Covered by unit tests for the flat and rdf:Seq forms plus a committed FOP-style sample (sample-fop.pdf) carrying an uncompressed XMP packet.