### PR TITLE
Guard PDF ID scan on unterminated strings

### DIFF
--- a/src/Tests/PdfNormalizerTests.cs
+++ b/src/Tests/PdfNormalizerTests.cs
@@ -106,6 +106,17 @@ public class PdfNormalizerTests
     }
 
     [Test]
+    public void HandlesUnterminatedFileIdWithoutOverrunning()
+    {
+        // A truncated /ID whose string runs to the end of the buffer with no closing '>'/')' (and no
+        // closing ']') must not scan past the buffer: the value is zeroed as far as it exists and the
+        // scan stops cleanly rather than throwing. Hex string form (no closing '>'):
+        Assert.That(Normalize("/ID [<ABCD"), Is.EqualTo("/ID [<0000"));
+        // Literal string form (no closing ')'):
+        Assert.That(Normalize("/ID [(ABCD"), Is.EqualTo("/ID [(0000"));
+    }
+
+    [Test]
     public void NormalizedDocumentStillLoads()
     {
         var data = File.ReadAllBytes("sample.pdf");

--- a/src/Verify.DocNet/PdfNormalizer.cs
+++ b/src/Verify.DocNet/PdfNormalizer.cs
@@ -124,14 +124,20 @@ static class PdfNormalizer
                     var start = i + 1;
                     i = FindByte(data, start, (byte) '>');
                     Overwrite(data, start, i, Fill.Hex);
-                    i++;
+                    if (i < data.Length)
+                    {
+                        i++;
+                    }
                 }
                 else if (data[i] == (byte) '(')
                 {
                     var start = i + 1;
                     i = FindLiteralEnd(data, start);
                     Overwrite(data, start, i, Fill.All);
-                    i++;
+                    if (i < data.Length)
+                    {
+                        i++;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Prevent index overruns when normalizing truncated `/ID` entries that end without closing `>` or `)`. The normalizer now only advances past terminators when they actually exist, so malformed buffers are zeroed safely up to available bytes. Added regression tests for unterminated hex and literal `/ID` forms.