### PR TITLE
Validate page selection arguments

### DIFF
--- a/src/Tests/PageSelectionTests.cs
+++ b/src/Tests/PageSelectionTests.cs
@@ -1,0 +1,31 @@
+[TestFixture]
+public class PageSelectionTests
+{
+    [Test]
+    public void SinglePageRejectsNegativeIndex()
+    {
+        // A negative index would render nothing and produce a confusing downstream error; reject it
+        // at the call site instead. Zero (the first page) remains valid.
+        var settings = new VerifySettings();
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.SinglePage(-1));
+    }
+
+    [Test]
+    public void PagesToIncludeRejectsNonPositiveCount()
+    {
+        // Zero or fewer pages leaves nothing to verify and drives a negative page range into the
+        // pdf subset; require at least one page.
+        var settings = new VerifySettings();
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.PagesToInclude(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.PagesToInclude(-1));
+    }
+
+    [Test]
+    public void AcceptsBoundaryValues()
+    {
+        // The lowest valid values must pass: page index 0 and a count of 1.
+        var settings = new VerifySettings();
+        Assert.DoesNotThrow(() => settings.SinglePage(0));
+        Assert.DoesNotThrow(() => settings.PagesToInclude(1));
+    }
+}

--- a/src/Verify.DocNet/VerifyDocNet.cs
+++ b/src/Verify.DocNet/VerifyDocNet.cs
@@ -18,8 +18,15 @@ public static partial class VerifyDocNet
         VerifierSettings.RegisterFileConverter<IDocReader>((target, context) => Convert(null, target, context));
     }
 
-    public static void PagesToInclude(this VerifySettings settings, int count) =>
+    public static void PagesToInclude(this VerifySettings settings, int count)
+    {
+        if (count < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count, "PagesToInclude count must be greater than or equal to 1.");
+        }
+
         settings.Context["VerifyDocNetPagesToInclude"] = count;
+    }
 
     public static SettingsTask PagesToInclude(this SettingsTask settings, int count)
     {
@@ -37,8 +44,15 @@ public static partial class VerifyDocNet
         return count;
     }
 
-    public static void SinglePage(this VerifySettings settings, int index) =>
-      settings.Context["VerifyDocNetSinglePage"] = index;
+    public static void SinglePage(this VerifySettings settings, int index)
+    {
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), index, "SinglePage index must be greater than or equal to 0.");
+        }
+
+        settings.Context["VerifyDocNetSinglePage"] = index;
+    }
 
     /// <summary>
     /// Zero based index of single page to include (overrules PagesToInclude when in range)


### PR DESCRIPTION
Add guard clauses to `VerifySettings.PagesToInclude` and `VerifySettings.SinglePage` to reject invalid values early with `ArgumentOutOfRangeException`. This prevents confusing downstream failures when page ranges are empty or negative. Also adds `PageSelectionTests` to cover rejected negative/non-positive inputs and accepted boundary values.